### PR TITLE
perf(remotion): phase 1 render speedups + performance investigation (#6)

### DIFF
--- a/REMOTION_PERFORMANCE.md
+++ b/REMOTION_PERFORMANCE.md
@@ -1,0 +1,329 @@
+# Remotion Rendering Performance Investigation
+
+> Issue: [#6 — Investigate video rendering performance improvements with Remotion](https://github.com/el-frontend/video-wizard/issues/6)
+> Date: 2026-07-23 · Remotion `4.0.405`
+
+## TL;DR
+
+The render pipeline leaves almost all of Remotion's performance levers at their
+defaults and serializes work in two places. The single highest-impact change is
+**passing render options to `renderMedia()`** — measured on the real
+composition, `x264Preset: 'veryfast'` + `offthreadVideoCacheSizeInBytes` cut
+render time **~21–27%** with a one-line change, no architecture work. These
+options live entirely in `apps/remotion-server/server/render-queue.ts`. A
+benchmark harness (below) measures each lever in isolation.
+
+Two counter-intuitive, empirically confirmed findings that shape the plan:
+**forcing `concurrency` higher did not help and sometimes _hurt_** (the workload
+is encode-bound and Remotion's default already uses ~half the cores), and
+**`chromiumOptions.gl: 'swangle'` was 2× slower on macOS** — so `gl` must never
+be hard-coded without benchmarking on the production OS. The real throughput win
+is _cross-render_ parallelism, not per-render concurrency.
+
+Headline findings:
+
+1. **`renderMedia()` runs with defaults** — no `concurrency`, `x264Preset`,
+   `offthreadVideoCacheSizeInBytes`, or `chromiumOptions`. See
+   `render-queue.ts:96`.
+2. **Two-layer serialization** — the worker dispatches up to `concurrency=2`
+   render jobs, but the Remotion server's queue processes renders **strictly
+   sequentially** (`render-queue.ts:150`, `queue = queue.then(...)`), and each
+   single render only uses Remotion's default concurrency (~half the cores).
+   Cores sit idle.
+3. **`remotion.config.ts` is dead on the render path** — `Config.*` from
+   `@remotion/cli/config` only affects the Remotion **CLI**, not the
+   `@remotion/renderer` Node API used by the server. So `jpeg` and the `angle`
+   OpenGL renderer set there are **not applied** to production renders.
+4. **A prior hardening fix regressed** — `shm_size: 2gb` + `RENDER_CONCURRENCY`
+   (added in a previous session to stop Chromium exhausting Docker's 64 MB
+   `/dev/shm`) are **no longer present** in the root `docker-compose.yml` after
+   the queue refactor.
+5. **The container renders in dev mode** — the root compose overrides the image
+   `CMD` with `pnpm dev` (`tsx watch`) and sets `NODE_ENV=development`.
+6. **The bundle is rebuilt on every boot** — `REMOTION_SERVE_URL` is empty, so
+   `bundle()` runs at startup with no persisted/cached artifact.
+
+---
+
+## 1. Current architecture
+
+```mermaid
+flowchart LR
+  U[User] -->|POST /api/render-video-subtitles| API[Next.js API route]
+  API -->|enqueue 'render' job| Q[(Postgres task queue)]
+  W[Worker loop\nconcurrency=2] -->|claimNext| Q
+  W -->|renderWithSubtitles| SVC[subtitle-generation-service]
+  SVC -->|POST /renders| RS[remotion-server\nExpress]
+  RS -->|createJob → sequential queue| RQ[render-queue.ts]
+  RQ -->|selectComposition + renderMedia| REM[(Remotion + Chromium)]
+  REM -->|OffthreadVideo HTTP GET| PY[processing-engine\nsource video]
+  RQ --> OUT[/renders/:id.mp4/]
+  SVC -->|poll every 2s| RS
+```
+
+Key files:
+
+| Concern                            | File                                                                   | Note                                                     |
+| ---------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------- |
+| Render engine call                 | `apps/remotion-server/server/render-queue.ts`                          | `renderMedia()` at line 96; sequential queue at line 150 |
+| Server boot / bundle               | `apps/remotion-server/server/index.ts`                                 | `bundle()` at 162, `ensureBrowser()` at 152              |
+| CLI-only config (unused by server) | `apps/remotion-server/remotion.config.ts`                              | jpeg + `angle` GL — not applied to Node API              |
+| Composition                        | `packages/remotion-compositions/src/compositions/VideoComposition.tsx` | `OffthreadVideo` + caption overlay                       |
+| Web → server bridge                | `apps/web/server/services/subtitle-generation-service.ts`              | POST + 2s poll (line 171, 217)                           |
+| Worker                             | `apps/web/server/worker/loop.ts`                                       | `concurrency=2` (default), `WORKER_CONCURRENCY`          |
+| Container                          | `apps/remotion-server/Dockerfile`, root `docker-compose.yml`           | dev-mode command, no `shm_size`, no limits               |
+
+---
+
+## 2. How rendering is configured today
+
+The entire per-render configuration is this call (`render-queue.ts:96`):
+
+```ts
+await renderMedia({
+  cancelSignal,
+  serveUrl,
+  composition,
+  inputProps,
+  codec: 'h264',
+  onProgress: (progress) => {
+    /* logs + updates job state */
+  },
+  outputLocation: path.join(rendersDir, `${jobId}.mp4`),
+});
+```
+
+Everything else is a Remotion default:
+
+- **`concurrency`**: unset → Remotion picks ~half the logical cores. On a
+  12-core host a single render uses ~6 workers; the other ~6 are idle, and no
+  second render runs because the server queue is sequential.
+- **`x264Preset`**: unset → `medium`. Faster presets trade a little file size
+  for markedly faster encoding.
+- **`offthreadVideoCacheSizeInBytes`**: unset → default cache. Larger cache
+  reduces repeated frame extraction from the source video.
+- **`chromiumOptions.gl`**: unset → platform default. `remotion.config.ts` sets
+  `angle`, but that only applies to the CLI, not this Node API path.
+- **`jpegQuality` / `imageFormat`**: unset. `renderMedia` defaults to `jpeg`,
+  which happens to match the (dead) config, so this one is coincidentally fine.
+
+---
+
+## 3. Benchmark methodology
+
+Harness: `apps/remotion-server/bench.mjs` (self-contained, committed with this
+investigation). It:
+
+1. Bundles the **real** `VideoWithSubtitles` composition once (measures
+   cold-start bundle time).
+2. Serves the sample video over HTTP — mirroring production, where
+   `OffthreadVideo` fetches the source from the processing-engine over HTTP.
+3. Calls `selectComposition` once (measures per-job selection cost) and reuses
+   the result so only `renderMedia()` is timed.
+4. Runs a discarded **warmup** render, then times each config, then re-runs the
+   baseline to measure drift/variance.
+5. Isolates one variable per config (baseline exactly mirrors `render-queue.ts`).
+
+Fixed workload: **1080×1920, 300 frames @ 30 fps (10 s), template `viral`**,
+source `A999_11151216_C035_clip_0s.mp4` (2.9 MB).
+
+> Note: the composition's per-frame `console.log` (B10) is active during these
+> runs, inflating **all** absolute times roughly equally — relative comparisons
+> between configs still hold, and removing the logging would lower the whole
+> column.
+
+> Caveat: benchmarks were run on **macOS/arm64 (12 cores, 24 GB)**. Production
+> renders on **Linux Docker**. CPU-bound gains (concurrency, encoder preset,
+> video cache) transfer well; the `gl` renderer choice is platform-specific and
+> must be re-validated on Linux (see §7).
+
+---
+
+## 4. Benchmark results
+
+Fixed per-render overhead (not part of the render loop, but paid per job/boot):
+
+| Stage                 | Time      | When paid                                             |
+| --------------------- | --------- | ----------------------------------------------------- |
+| `bundle()` cold-start | **2.7 s** | Once per server boot (rebuilt every boot today — B6)  |
+| `selectComposition()` | **6.6 s** | Per render job (browser launch + `calculateMetadata`) |
+
+### 4.1 Single-variable isolation (render-only, 10 s clip)
+
+Each config adds exactly one option to the baseline. Baseline drift on a
+re-run was **+1%**, so differences below ~2% are noise.
+
+| Config                                  | Time      | vs baseline             |
+| --------------------------------------- | --------- | ----------------------- |
+| baseline (current)                      | 11.3 s    | —                       |
+| + `concurrency = 12` (all cores)        | 11.4 s    | +1% (no gain)           |
+| **+ `x264Preset: 'veryfast'`**          | **8.2 s** | **−27%**                |
+| + `offthreadVideoCacheSizeInBytes: 2GB` | 10.3 s    | −9%                     |
+| + `chromiumOptions.gl: 'swangle'`       | 23.6 s    | **+109% (much slower)** |
+| COMBINED incl. `gl: swangle`            | 22.4 s    | +98%                    |
+
+Reading the results:
+
+- **`x264Preset` is the dominant lever** on this workload — the render is
+  encode-bound, not decode- or paint-bound. `veryfast` alone is −27%.
+- **`offthreadVideoCacheSizeInBytes` gives a modest −9%** by avoiding repeated
+  source-frame extraction.
+- **Forcing `concurrency` to all cores does nothing here** — Remotion's default
+  already uses ~half the cores (6 worker tabs were observed) and the workload is
+  encode-bound, so more paint workers don't help. This is why the real
+  throughput win is _cross-render_ parallelism (B1), not per-render concurrency.
+- **`gl: 'swangle'` is 2× slower on macOS/arm64**, where the default hardware GL
+  is fast. On Linux headless the trade-off often reverses — this is the single
+  clearest reason **not to hard-code a `gl` value** without benchmarking on the
+  actual production OS.
+
+### 4.2 Recommended stack (no `gl` override)
+
+Second run, stacking the levers that actually helped (baseline drifted to
+10.1 s this run — see the variance note below):
+
+| Config                                  | Time      | vs baseline               |
+| --------------------------------------- | --------- | ------------------------- |
+| baseline (current)                      | 10.1 s    | —                         |
+| **`veryfast` + `cache=2GB`**            | **8.0 s** | **−21%**                  |
+| `veryfast` + `cache` + `concurrency=12` | 8.7 s     | −14% (concurrency _hurt_) |
+| `ultrafast` + `cache=2GB`               | 7.5 s     | −26%                      |
+
+- **`veryfast` + `offthreadVideoCacheSizeInBytes` is the recommended default**:
+  ~−21% render time with a negligible quality/size cost.
+- **Forcing `concurrency` to all cores _regressed_ the stack** (8.0 s → 8.7 s) —
+  oversubscription/contention. Leave `concurrency` at Remotion's default (or
+  tune conservatively); do not crank it.
+- **`ultrafast` is fastest (−26%)** but visibly increases file size and reduces
+  quality — only worth it if encode time dominates and quality budget allows.
+
+> Variance note: baseline was 11.3 s (run 1) vs 10.1 s (run 2) — ~10% run-to-run
+> drift on a shared dev laptop. Trust the **relative deltas within a run**, not
+> absolute times across runs. Also note `bundle()` was 2.7 s cold (run 1) but
+> ~0.6 s warm (run 2) because Remotion caches the webpack bundle between runs —
+> the 2.7 s is the true first-boot cost that B6 pays on every container start.
+
+---
+
+## 5. Bottlenecks identified
+
+| #   | Bottleneck                                                                                                                                                    | Where                                                               | Type             |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------- |
+| B1  | Remotion server queue is strictly sequential — one render at a time regardless of host capacity                                                               | `render-queue.ts:150`                                               | Parallelism      |
+| B2  | Single render leaves ~half the cores idle (default concurrency) — but this workload is **encode-bound**, so raising concurrency alone did not help (measured) | `render-queue.ts:96`                                                | CPU              |
+| B3  | Encoder preset defaults to `medium` — the dominant lever here (−21–27% measured)                                                                              | `render-queue.ts:96`                                                | CPU (encode)     |
+| B4  | Source video fetched over HTTP per render; `offthreadVideoCacheSizeInBytes` unset                                                                             | `render-queue.ts:96` + `VideoComposition.tsx:43`                    | I/O              |
+| B5  | `chromiumOptions.gl` not set on Node API; `remotion.config.ts` is CLI-only and ignored                                                                        | `render-queue.ts` / `remotion.config.ts`                            | Config           |
+| B6  | Bundle rebuilt on every server boot (`REMOTION_SERVE_URL` empty)                                                                                              | `index.ts:162`                                                      | Cold start       |
+| B7  | Container runs dev mode (`pnpm dev` / `tsx watch`, `NODE_ENV=development`)                                                                                    | root `docker-compose.yml`                                           | Runtime overhead |
+| B8  | `shm_size` + `RENDER_CONCURRENCY` hardening regressed after refactor → Chromium `/dev/shm` exhaustion risk                                                    | root `docker-compose.yml`                                           | Stability        |
+| B9  | No CPU/memory limits, no render metrics/observability                                                                                                         | root `docker-compose.yml`                                           | Ops              |
+| B10 | Composition logs to `console` **every frame** (forwarded from Chromium to Node per frame)                                                                     | `useActiveSubtitle.ts:66`, `VideoComposition.tsx:27`, `Root.tsx:47` | CPU (hot path)   |
+
+Note: there is **no CI render pipeline** (no `.github/workflows`), so the issue's
+"CI" profiling target does not currently exist — rendering happens only in the
+`remotion-server` container.
+
+---
+
+## 6. Optimization catalog (pros / cons)
+
+| Optimization                                                                        | Measured / est. impact                                     | Effort | Risk | Pros                                                          | Cons                                                                |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------ | ---- | ------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **`x264Preset: 'veryfast'`**                                                        | **−27% measured** (dominant lever)                         | XS     | Low  | Large encode speedup; one-line                                | Slightly larger files at same CRF; marginal quality delta           |
+| **`offthreadVideoCacheSizeInBytes: 2GB`**                                           | **−9% measured**                                           | XS     | Low  | Fewer source re-decodes                                       | Uses RAM; must bound in containers                                  |
+| **`veryfast` + cache together**                                                     | **−21% measured** (recommended)                            | XS     | Low  | Best safe stack; one-line                                     | —                                                                   |
+| **`x264Preset: 'ultrafast'`**                                                       | **−26% measured**                                          | XS     | Med  | Fastest encode                                                | Noticeably larger files / lower quality                             |
+| **Set `concurrency` explicitly**                                                    | **~0%, sometimes worse** (measured; encode-bound workload) | XS     | Med  | —                                                             | Forcing all cores _regressed_ the stack; oversubscription           |
+| **`chromiumOptions.gl`** (`swangle`/`angle-egl`/…)                                  | **+109% (swangle) on macOS**; platform-dependent           | S      | Med  | Can be faster/stabler on Linux headless                       | Wrong value 2× slower or breaks rendering; **must** test on prod OS |
+| **Concurrent server queue** (N renders in parallel)                                 | High (throughput)                                          | M      | Med  | The real throughput win; aligns with worker `concurrency=2`   | Memory pressure; needs a concurrency cap + backpressure             |
+| **Persist bundle at build / set `REMOTION_SERVE_URL`**                              | Med (cold start only)                                      | S      | Low  | Removes per-boot bundle cost                                  | Build step / artifact hosting to manage                             |
+| **Run prod mode in container** (`pnpm build` + `pnpm start`, `NODE_ENV=production`) | Low–Med                                                    | S      | Low  | Removes watch overhead; correct env                           | Needs Dockerfile build stage (currently missing)                    |
+| **Restore `shm_size: 2gb`**                                                         | Stability (not speed)                                      | XS     | Low  | Prevents Chromium crashes under concurrency                   | None meaningful                                                     |
+| **Remove per-frame `console.log`** (gate behind a debug flag)                       | Low–Med                                                    | XS     | Low  | Removes per-frame browser→Node log forwarding on the hot path | None (keep behind env flag for debugging)                           |
+| **`jpegQuality` tuning**                                                            | Low                                                        | XS     | Low  | Minor frame-extraction speed                                  | Quality tradeoff                                                    |
+| **Hardware-accelerated encode** (`hardwareAcceleration`)                            | Med–High (where available)                                 | M      | Med  | Offloads encode to GPU/VideoToolbox                           | Availability varies; Docker GPU passthrough non-trivial             |
+| **Distributed rendering (Remotion Lambda / cloud)**                                 | Very High (scale)                                          | L      | High | Near-linear scale, no local ceiling                           | Cost, AWS setup, architecture change; overkill for current volume   |
+
+---
+
+## 7. Recommended implementation plan
+
+### Phase 1 — Config quick wins (no architecture change)
+
+Target: `render-queue.ts` `renderMedia()` call + Docker hardening.
+
+The measured, low-risk change (add to the `renderMedia()` call at
+`render-queue.ts:96`):
+
+```ts
+await renderMedia({
+  // ...existing...
+  x264Preset: 'veryfast', // −27% (dominant lever)
+  offthreadVideoCacheSizeInBytes: 2 * 1024 ** 3, // −9%, bounded for containers
+  // do NOT set `concurrency` here — leave Remotion's default (forcing it hurt)
+  // do NOT set `chromiumOptions.gl` until benchmarked on Linux (swangle was 2× slower on macOS)
+});
+```
+
+- Restore `shm_size: '2gb'` on the `remotion-server` service in the root
+  `docker-compose.yml` (regression fix — see B8).
+- Delete or document `remotion.config.ts` so it is not mistaken for live config.
+- Gate the composition's per-frame `console.log` (B10) behind a debug env flag.
+- **Verify:** re-run `bench.mjs` **inside the Linux container** to confirm the
+  ~−20% holds there and to separately test whether a `gl` value (`swangle` /
+  `angle-egl`) helps on Linux before adopting one. Bound `offthreadVideoCache`
+  against the container memory limit.
+
+### Phase 2 — Throughput / parallelism
+
+This is the larger structural win. Single-render latency is already near the
+encode floor after Phase 1; throughput is capped by two serialization layers.
+
+- Replace the sequential `queue = queue.then(...)` (`render-queue.ts:150`) with a
+  **bounded concurrent queue** (cap = `RENDER_CONCURRENCY` env), so the server
+  runs multiple renders in parallel and actually matches the worker's
+  `concurrency=2`. Today the worker can dispatch 2 renders but the server runs
+  them one at a time.
+- Because a single render is encode-bound and does **not** benefit from extra
+  per-render concurrency (measured), spend the core budget on **cross-render**
+  parallelism instead — e.g. 2 concurrent renders at default per-render
+  concurrency on a 12-core box — and cap total in-flight to avoid `/dev/shm`/OOM.
+- **Verify:** throughput (renders/min) under a burst of N jobs, not just
+  single-render latency.
+
+### Phase 3 — Infra / cold start / scale
+
+- Pre-bundle the compositions at image build time and set `REMOTION_SERVE_URL`,
+  eliminating per-boot bundling (B6).
+- Add a proper production Dockerfile build stage (`tsc` → `node dist`) and run
+  the container in production mode (B7). The current `Dockerfile` `CMD` is
+  `pnpm start` but there is **no build step**, which is why compose overrides it
+  with `pnpm dev`.
+- Add render metrics (duration, concurrency, memory) and CPU/memory limits (B9).
+- Evaluate `hardwareAcceleration` and, only if volume grows past a single host,
+  **Remotion Lambda / distributed rendering** (high impact, high cost/effort).
+
+---
+
+## 8. Risks & caveats
+
+- **macOS vs Linux**: `gl` renderer and absolute times differ; re-benchmark in
+  the container before committing a `gl` value.
+- **Memory**: higher `concurrency` and a concurrent queue multiply Chromium
+  memory; without `shm_size` and CPU/mem limits this reproduces the earlier
+  "cannot allocate memory" / "disk space low" failures.
+- **Quality**: faster `x264Preset` slightly increases file size at a fixed CRF;
+  validate output quality is acceptable for social formats (it generally is).
+
+---
+
+## Appendix — running the benchmark
+
+```bash
+cd apps/remotion-server
+node bench.mjs
+```
+
+Edits the config list at the top of `bench.mjs` to add/remove variants. Renders
+are written to a scratch dir and discarded; only timings are reported.

--- a/apps/remotion-server/bench.mjs
+++ b/apps/remotion-server/bench.mjs
@@ -1,0 +1,174 @@
+/**
+ * Remotion render performance benchmark harness (issue #6).
+ *
+ * Bundles the real `VideoWithSubtitles` composition once, serves a local
+ * sample video over HTTP (mirroring the production path where the source is
+ * fetched from the processing-engine over HTTP), then times renderMedia()
+ * under a baseline config (exactly what render-queue.ts passes today) versus
+ * several optimization variants — in isolation, one variable at a time.
+ *
+ * Usage: node bench.mjs
+ */
+import { bundle } from '@remotion/bundler';
+import { renderMedia, selectComposition, ensureBrowser } from '@remotion/renderer';
+import { createServer } from 'node:http';
+import { statSync, createReadStream, mkdirSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CORES = os.cpus().length;
+
+// --- Config -----------------------------------------------------------------
+const SAMPLE_VIDEO = path.resolve(
+  __dirname,
+  '../processing-engine/output/A999_11151216_C035_clip_0s.mp4'
+);
+const OUT_DIR = path.join(os.tmpdir(), 'remotion-bench-renders');
+const VIDEO_PORT = 4599;
+const DURATION_FRAMES = 300; // fixed 10s @ 30fps so every config renders identical work
+const TEMPLATE = 'viral';
+const GB = 1024 * 1024 * 1024;
+
+// Generate ~10s of subtitles in SECONDS (composition expects seconds).
+const subtitles = Array.from({ length: 10 }, (_, i) => ({
+  id: i + 1,
+  start: i,
+  end: i + 1,
+  text: `This is benchmark subtitle segment number ${i + 1} for testing`,
+}));
+
+const inputProps = {
+  videoUrl: `http://localhost:${VIDEO_PORT}/video.mp4`,
+  subtitles,
+  template: TEMPLATE,
+  language: 'en',
+  aspectRatio: '9:16',
+  backgroundColor: '#000000',
+  durationInFrames: DURATION_FRAMES,
+};
+
+// Each config layers optimizations onto the baseline render options.
+// baseline mirrors render-queue.ts exactly: only codec is set.
+const CONFIGS = [
+  // Single-variable isolation (one option added per row).
+  { name: 'baseline (current)', opts: {} },
+  { name: '+ concurrency=cores', opts: { concurrency: CORES } },
+  { name: '+ x264Preset=veryfast', opts: { x264Preset: 'veryfast' } },
+  { name: '+ offthreadCache=2GB', opts: { offthreadVideoCacheSizeInBytes: 2 * GB } },
+  // gl is platform-specific: swangle was ~2x slower on macOS; test on Linux.
+  { name: '+ gl=swangle', opts: { chromiumOptions: { gl: 'swangle' } } },
+  // Recommended stack (no gl override, no forced concurrency).
+  { name: 'RECOMMENDED (veryfast+cache)', opts: { x264Preset: 'veryfast', offthreadVideoCacheSizeInBytes: 2 * GB } },
+  { name: 'ultrafast+cache', opts: { x264Preset: 'ultrafast', offthreadVideoCacheSizeInBytes: 2 * GB } },
+];
+
+// --- Static video server ----------------------------------------------------
+function startVideoServer() {
+  const size = statSync(SAMPLE_VIDEO).size;
+  const server = createServer((req, res) => {
+    const range = req.headers.range;
+    if (range) {
+      const [startStr, endStr] = range.replace(/bytes=/, '').split('-');
+      const start = parseInt(startStr, 10);
+      const end = endStr ? parseInt(endStr, 10) : size - 1;
+      res.writeHead(206, {
+        'Content-Range': `bytes ${start}-${end}/${size}`,
+        'Accept-Ranges': 'bytes',
+        'Content-Length': end - start + 1,
+        'Content-Type': 'video/mp4',
+      });
+      createReadStream(SAMPLE_VIDEO, { start, end }).pipe(res);
+    } else {
+      res.writeHead(200, { 'Content-Length': size, 'Content-Type': 'video/mp4' });
+      createReadStream(SAMPLE_VIDEO).pipe(res);
+    }
+  });
+  return new Promise((resolve) => server.listen(VIDEO_PORT, () => resolve(server)));
+}
+
+const ms = (ns) => Number(ns) / 1e6;
+const now = () => process.hrtime.bigint();
+
+async function timeRender(label, serveUrl, composition, opts) {
+  const out = path.join(OUT_DIR, `${label.replace(/[^a-z0-9]/gi, '_')}.mp4`);
+  const t0 = now();
+  await renderMedia({
+    serveUrl,
+    composition,
+    inputProps,
+    codec: 'h264',
+    outputLocation: out,
+    onProgress: () => {}, // no-op, kept identical across configs
+    logLevel: 'error',
+    ...opts,
+  });
+  return ms(now() - t0) / 1000; // seconds
+}
+
+async function main() {
+  console.log(`\n=== Remotion render benchmark ===`);
+  console.log(`Machine: ${CORES} cores, ${os.platform()} ${os.arch()}, ${(os.totalmem() / GB).toFixed(1)}GB RAM`);
+  console.log(`Sample: ${path.basename(SAMPLE_VIDEO)} (${(statSync(SAMPLE_VIDEO).size / 1024 / 1024).toFixed(1)}MB)`);
+  console.log(`Render target: 1080x1920, ${DURATION_FRAMES} frames @30fps (10s), template=${TEMPLATE}\n`);
+
+  rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  await ensureBrowser();
+  const server = await startVideoServer();
+
+  // Cold-start cost: bundle (mirrors index.ts bundling on server startup).
+  let t = now();
+  const serveUrl = await bundle({
+    entryPoint: path.resolve(__dirname, '../../packages/remotion-compositions/src/index.ts'),
+  });
+  const bundleSec = ms(now() - t) / 1000;
+  console.log(`Bundle (cold-start, once per server boot): ${bundleSec.toFixed(1)}s`);
+
+  // Per-job composition selection cost (browser launch + calculateMetadata).
+  t = now();
+  const composition = await selectComposition({ serveUrl, id: 'VideoWithSubtitles', inputProps });
+  const selectSec = ms(now() - t) / 1000;
+  console.log(`selectComposition (per job): ${selectSec.toFixed(1)}s`);
+  console.log(`Resolved: ${composition.width}x${composition.height}, ${composition.durationInFrames} frames\n`);
+
+  // Warmup render (discarded) so disk/OS caches are warm and the first real
+  // config isn't penalized.
+  process.stdout.write('warmup render... ');
+  const warm = await timeRender('warmup', serveUrl, composition, {});
+  console.log(`${warm.toFixed(1)}s (discarded)\n`);
+
+  const results = [];
+  for (const cfg of CONFIGS) {
+    process.stdout.write(`${cfg.name.padEnd(24)} ... `);
+    const sec = await timeRender(cfg.name, serveUrl, composition, cfg.opts);
+    console.log(`${sec.toFixed(1)}s`);
+    results.push({ name: cfg.name, sec });
+  }
+
+  // Re-run baseline to gauge drift/variance.
+  process.stdout.write(`baseline (re-run/drift)  ... `);
+  const drift = await timeRender('baseline_rerun', serveUrl, composition, {});
+  console.log(`${drift.toFixed(1)}s\n`);
+
+  const base = results[0].sec;
+  console.log('=== RESULTS (render-only, 10s clip) ===');
+  console.log('config'.padEnd(26) + 'time'.padEnd(10) + 'vs baseline');
+  for (const r of results) {
+    const speedup = ((base - r.sec) / base) * 100;
+    const tag = r.name === 'baseline (current)' ? '—' : `${speedup >= 0 ? '-' : '+'}${Math.abs(speedup).toFixed(0)}%`;
+    console.log(r.name.padEnd(26) + `${r.sec.toFixed(1)}s`.padEnd(10) + tag);
+  }
+  console.log(`\nbaseline drift: ${base.toFixed(1)}s -> ${drift.toFixed(1)}s (${(((drift - base) / base) * 100).toFixed(0)}%)`);
+  console.log(`\nJSON: ${JSON.stringify({ machine: { cores: CORES }, bundleSec, selectSec, results, drift })}`);
+
+  server.close();
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error('Benchmark failed:', e);
+  process.exit(1);
+});

--- a/apps/remotion-server/server/render-queue.ts
+++ b/apps/remotion-server/server/render-queue.ts
@@ -1,10 +1,24 @@
-import {
-    makeCancelSignal,
-    renderMedia,
-    selectComposition,
-} from '@remotion/renderer';
+import { makeCancelSignal, renderMedia, selectComposition } from '@remotion/renderer';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
+
+/**
+ * Render tuning — see REMOTION_PERFORMANCE.md (issue #6).
+ *
+ * `x264Preset: 'veryfast'` + a bounded off-thread video cache cut render time
+ * ~21% in benchmarks with negligible quality cost. Concurrency is left at
+ * Remotion's default unless `RENDER_CONCURRENCY` is set: forcing it higher was
+ * neutral-to-worse on this encode-bound workload, while a container may want to
+ * cap it *lower* to bound Chromium's memory footprint. `chromiumOptions.gl` is
+ * intentionally NOT set — the fast value is platform-specific (`swangle` was 2×
+ * slower on macOS), so only set `RENDER_GL` after benchmarking on the target OS.
+ */
+const OFFTHREAD_VIDEO_CACHE_BYTES =
+  Number(process.env.RENDER_OFFTHREAD_CACHE_MB ?? 2048) * 1024 * 1024;
+
+const RENDER_CONCURRENCY = process.env.RENDER_CONCURRENCY
+  ? Number(process.env.RENDER_CONCURRENCY)
+  : undefined;
 
 /**
  * Job data structure
@@ -99,6 +113,9 @@ export const makeRenderQueue = ({
         composition,
         inputProps,
         codec: 'h264',
+        x264Preset: 'veryfast',
+        offthreadVideoCacheSizeInBytes: OFFTHREAD_VIDEO_CACHE_BYTES,
+        ...(RENDER_CONCURRENCY ? { concurrency: RENDER_CONCURRENCY } : {}),
         onProgress: (progress) => {
           console.info(`[${jobId}] Render progress: ${Math.round(progress.progress * 100)}%`);
           jobs.set(jobId, {
@@ -131,13 +148,7 @@ export const makeRenderQueue = ({
   /**
    * Adds a job to the render queue
    */
-  const queueRender = async ({
-    jobId,
-    data,
-  }: {
-    jobId: string;
-    data: JobData;
-  }) => {
+  const queueRender = async ({ jobId, data }: { jobId: string; data: JobData }) => {
     jobs.set(jobId, {
       status: 'queued',
       data,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,9 @@ services:
       - video-wizard-network
     ports:
       - '3001:3001'
+    # Chromium (via Remotion) needs a large /dev/shm; Docker's 64MB default
+    # causes "cannot allocate memory" / "disk space low" render failures.
+    shm_size: '2gb'
     env_file:
       - ./apps/remotion-server/.env
     environment:
@@ -87,6 +90,10 @@ services:
       - PORT=3001
       - RENDERS_DIR=./renders
       - PYTHON_ENGINE_URL=http://processing-engine:8000
+      # Cap concurrent Chromium tabs per render to bound memory in the
+      # container (see REMOTION_PERFORMANCE.md). Raise/remove on hosts with
+      # more RAM; leave unset to use Remotion's default (~half the cores).
+      - RENDER_CONCURRENCY=2
     volumes:
       - ./packages/remotion-compositions:/app/packages/remotion-compositions
       - ./apps/remotion-server/server:/app/apps/remotion-server/server

--- a/packages/remotion-compositions/src/hooks/useActiveSubtitle.ts
+++ b/packages/remotion-compositions/src/hooks/useActiveSubtitle.ts
@@ -1,6 +1,14 @@
 import { useMemo } from 'react';
 import type { SubtitleSegment } from '../types';
 
+/**
+ * Per-frame debug logging is off by default: this hook runs on every frame of
+ * every render worker, so logging here forwards a message from Chromium to Node
+ * on the render hot path (see REMOTION_PERFORMANCE.md, B10). Flip to `true`
+ * locally when debugging subtitle timing.
+ */
+const DEBUG = false;
+
 interface ActiveSubtitleResult {
   currentWord: string;
   currentSegment: SubtitleSegment | null;
@@ -10,14 +18,14 @@ interface ActiveSubtitleResult {
 
 /**
  * Hook: useActiveSubtitle
- * 
+ *
  * Calculates which word should be displayed at the current time
- * 
+ *
  * Logic Flow:
  * 1. Find active segment based on start/end timestamps
  * 2. If segment has word-level timing, find active word
  * 3. Otherwise, display entire segment text
- * 
+ *
  * @param subtitles - Array of subtitle segments with timing
  * @param currentTime - Current playback time in seconds
  * @returns Active word and segment information
@@ -36,7 +44,7 @@ export function useActiveSubtitle(
     const adjustedTime = currentTime - SUBTITLE_OFFSET;
 
     // Debug: Log on first frame
-    if (currentTime === 0 && subtitles.length > 0) {
+    if (DEBUG && currentTime === 0 && subtitles.length > 0) {
       console.log('[useActiveSubtitle] Initial state:', {
         subtitleCount: subtitles.length,
         firstSubtitle: subtitles[0],
@@ -52,7 +60,7 @@ export function useActiveSubtitle(
 
     if (!currentSegment) {
       // Debug: Log when no segment is found at specific times
-      if (adjustedTime > 0 && adjustedTime < 5) {
+      if (DEBUG && adjustedTime > 0 && adjustedTime < 5) {
         console.log('[useActiveSubtitle] No active segment at time:', {
           currentTime,
           adjustedTime,
@@ -66,16 +74,18 @@ export function useActiveSubtitle(
       };
     }
 
-    // Debug: Log when segment becomes active
-    console.log('[useActiveSubtitle] Active segment:', {
-      currentTime,
-      adjustedTime,
-      segment: {
-        start: currentSegment.start,
-        end: currentSegment.end,
-        text: currentSegment.text,
-      },
-    });
+    // Debug: Log when segment becomes active (fires every frame — gated)
+    if (DEBUG) {
+      console.log('[useActiveSubtitle] Active segment:', {
+        currentTime,
+        adjustedTime,
+        segment: {
+          start: currentSegment.start,
+          end: currentSegment.end,
+          text: currentSegment.text,
+        },
+      });
+    }
 
     // If segment has word-level timing, find the active word
     if (currentSegment.words && currentSegment.words.length > 0) {


### PR DESCRIPTION
Closes #6 (investigation + Phase 1). Phases 2–3 tracked as documented next steps.

## Summary
Investigated the Remotion render pipeline and shipped the low-risk **Phase 1** wins. `renderMedia()` previously ran with all defaults; a benchmark harness on the real composition measured each lever in isolation.

| Config (10s clip, 1080×1920) | Time | vs baseline |
|---|---|---|
| baseline (current) | 11.3s | — |
| **`x264Preset: 'veryfast'`** | 8.2s | **−27%** |
| `offthreadVideoCacheSizeInBytes: 2GB` | 10.3s | −9% |
| **veryfast + cache (adopted)** | 8.0s | **~−21%** |
| `concurrency = all cores` | 11.4s | +1% (no gain) |
| `chromiumOptions.gl: 'swangle'` | 23.6s | +109% (macOS) |

## Changes (config only — no architecture change)
- **`render-queue.ts`**: add `x264Preset: 'veryfast'` + bounded `offthreadVideoCacheSizeInBytes`; optional `RENDER_CONCURRENCY` env (defaults to Remotion's default). `gl` left unset — the fast value is platform-specific and must be benchmarked on the prod OS.
- **`docker-compose.yml`**: restore `shm_size: '2gb'` (regression fix — Chromium `/dev/shm` exhaustion caused "cannot allocate memory" failures) and cap `RENDER_CONCURRENCY=2` in the container to bound memory.
- **`useActiveSubtitle.ts`**: gate the per-frame `console.log` behind a `DEBUG` flag — it was forwarding a Chromium→Node log on **every frame** of every render.

## Docs / tooling
- **`REMOTION_PERFORMANCE.md`**: full investigation — architecture, 10 bottlenecks, benchmark tables, optimization catalog with pros/cons, and a phased plan.
- **`bench.mjs`**: reproducible benchmark harness (`cd apps/remotion-server && node bench.mjs`).

## Key findings that shaped the plan
1. **`veryfast` + cache is the win** (~−21%, one line) — the workload is encode-bound.
2. **Forcing concurrency doesn't help / hurts.** The real throughput win is *cross-render* parallelism — blocked today by a two-layer serialization (worker dispatches 2 renders, but `render-queue.ts` runs them sequentially). → Phase 2.
3. **`gl` is platform-specific** (`swangle` was 2× slower on macOS) — never hard-code it.
4. **`remotion.config.ts` is dead** on the render path (CLI-only, not the Node API the server uses).

## Verification
- `tsc --noEmit` passes for `remotion-server` and `@workspace/remotion-compositions`.
- Render options validated at runtime by the benchmark.
- Not run: full Docker stack render (Phase 1 is config-only; options are benchmark-proven).

## Next steps (documented, not in this PR)
- **Phase 2**: bounded concurrent server queue (real throughput win).
- **Phase 3**: pre-bundle at build + `REMOTION_SERVE_URL`, production Dockerfile build stage + prod mode, render metrics/limits, evaluate hardware accel / distributed rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)