### PR TITLE
perf(remotion): phase 2 — bounded concurrent render queue (#6)

### DIFF
--- a/REMOTION_PERFORMANCE.md
+++ b/REMOTION_PERFORMANCE.md
@@ -286,14 +286,27 @@ was capped by the server serializing every render.
 the container sets **2** to match the worker's dispatch concurrency). Cancelling
 a queued job now also removes it from the pending list.
 
-Two independent knobs, deliberately separate:
+All tuning knobs (every one validated — an invalid value warns and falls back
+rather than silently becoming `NaN`):
 
-| Env                      | Controls                            | Default          | Container |
-| ------------------------ | ----------------------------------- | ---------------- | --------- |
-| `MAX_CONCURRENT_RENDERS` | render **jobs** in parallel         | 1                | 2         |
-| `RENDER_CONCURRENCY`     | Chromium **tabs** within one render | Remotion default | 2         |
+| Env                         | Controls                            | Default          | Container |
+| --------------------------- | ----------------------------------- | ---------------- | --------- |
+| `MAX_CONCURRENT_RENDERS`    | render **jobs** in parallel         | 1                | 2         |
+| `RENDER_CONCURRENCY`        | Chromium **tabs** within one render | Remotion default | 2         |
+| `RENDER_TIMEOUT_MS`         | per-render timeout                  | 300000 (5 min)   | —         |
+| `RENDER_OFFTHREAD_CACHE_MB` | off-thread video cache              | 2048             | —         |
 
-Total Chromium load ≈ product of the two — size both against RAM and `/dev/shm`.
+The first two are deliberately separate: total Chromium load ≈ their product, so
+size both against RAM and `/dev/shm`. The per-render timeout stops a wedged job
+from occupying a pool slot forever — which matters more now that slots are
+finite. Progress logging is also throttled to whole-percent changes, since
+`onProgress` fires far more often than that and concurrent renders interleave.
+
+> Credit: the per-render timeout, env validation, and progress-log throttling
+> were adapted from the earlier draft PR #12, which independently converged on
+> the same pool design. That PR also set `enableMultiProcessOnLinux: true`, which
+> is **not** carried over — it caused the Chromium `/dev/shm` exhaustion that B8
+> hardens against.
 
 **Measured** (3-job burst, `verify-queue.ts`):
 

--- a/REMOTION_PERFORMANCE.md
+++ b/REMOTION_PERFORMANCE.md
@@ -209,7 +209,7 @@ Second run, stacking the levers that actually helped (baseline drifted to
 
 | #   | Bottleneck                                                                                                                                                    | Where                                                               | Type             |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------- |
-| B1  | Remotion server queue is strictly sequential — one render at a time regardless of host capacity                                                               | `render-queue.ts:150`                                               | Parallelism      |
+| B1  | ~~Remotion server queue is strictly sequential — one render at a time~~ — **fixed in Phase 2** (bounded pool, `MAX_CONCURRENT_RENDERS`)                       | `render-queue.ts`                                                   | Parallelism      |
 | B2  | Single render leaves ~half the cores idle (default concurrency) — but this workload is **encode-bound**, so raising concurrency alone did not help (measured) | `render-queue.ts:96`                                                | CPU              |
 | B3  | Encoder preset defaults to `medium` — the dominant lever here (−21–27% measured)                                                                              | `render-queue.ts:96`                                                | CPU (encode)     |
 | B4  | Source video fetched over HTTP per render; `offthreadVideoCacheSizeInBytes` unset                                                                             | `render-queue.ts:96` + `VideoComposition.tsx:43`                    | I/O              |
@@ -275,22 +275,38 @@ await renderMedia({
   `angle-egl`) helps on Linux before adopting one. Bound `offthreadVideoCache`
   against the container memory limit.
 
-### Phase 2 — Throughput / parallelism
+### Phase 2 — Throughput / parallelism ✅ IMPLEMENTED
 
-This is the larger structural win. Single-render latency is already near the
-encode floor after Phase 1; throughput is capped by two serialization layers.
+Single-render latency is already near the encode floor after Phase 1; throughput
+was capped by the server serializing every render.
 
-- Replace the sequential `queue = queue.then(...)` (`render-queue.ts:150`) with a
-  **bounded concurrent queue** (cap = `RENDER_CONCURRENCY` env), so the server
-  runs multiple renders in parallel and actually matches the worker's
-  `concurrency=2`. Today the worker can dispatch 2 renders but the server runs
-  them one at a time.
-- Because a single render is encode-bound and does **not** benefit from extra
-  per-render concurrency (measured), spend the core budget on **cross-render**
-  parallelism instead — e.g. 2 concurrent renders at default per-render
-  concurrency on a 12-core box — and cap total in-flight to avoid `/dev/shm`/OOM.
-- **Verify:** throughput (renders/min) under a burst of N jobs, not just
-  single-render latency.
+**What shipped:** the sequential `queue = queue.then(...)` is replaced with a
+**bounded concurrent pool** in `render-queue.ts`, gated by a new
+`MAX_CONCURRENT_RENDERS` env (default **1** — identical to the old behaviour;
+the container sets **2** to match the worker's dispatch concurrency). Cancelling
+a queued job now also removes it from the pending list.
+
+Two independent knobs, deliberately separate:
+
+| Env                      | Controls                            | Default          | Container |
+| ------------------------ | ----------------------------------- | ---------------- | --------- |
+| `MAX_CONCURRENT_RENDERS` | render **jobs** in parallel         | 1                | 2         |
+| `RENDER_CONCURRENCY`     | Chromium **tabs** within one render | Remotion default | 2         |
+
+Total Chromium load ≈ product of the two — size both against RAM and `/dev/shm`.
+
+**Measured** (3-job burst, `verify-queue.ts`):
+
+| Setting                    | Peak concurrent | Completed | Wall clock |
+| -------------------------- | --------------- | --------- | ---------- |
+| default (=1)               | 1               | 3/3       | 11.7 s     |
+| `MAX_CONCURRENT_RENDERS=2` | 2               | 3/3       | **10.1 s** |
+
+Honest caveat: only ~14% on this micro-benchmark, because each render already
+uses ~half the cores by default, so 2 jobs × 6 tabs saturates a 12-core box.
+The gain is larger where per-render concurrency is **capped** (the container runs
+2 × 2 = 4 tabs, leaving headroom) or on hosts with spare cores — and the hard
+serialization ceiling is now gone, which is what mattered structurally.
 
 ### Phase 3 — Infra / cold start / scale
 
@@ -318,12 +334,28 @@ encode floor after Phase 1; throughput is capped by two serialization layers.
 
 ---
 
-## Appendix — running the benchmark
+## Appendix — running the tools
+
+Both tools render a local sample video. `apps/processing-engine/output/` is
+gitignored, so point them at a file you have.
+
+**Benchmark render settings:**
 
 ```bash
 cd apps/remotion-server
 node bench.mjs
 ```
 
-Edits the config list at the top of `bench.mjs` to add/remove variants. Renders
+Edit the config list at the top of `bench.mjs` to add/remove variants. Renders
 are written to a scratch dir and discarded; only timings are reported.
+
+**Verify the concurrent queue (Phase 2):**
+
+```bash
+cd apps/remotion-server
+MAX_CONCURRENT_RENDERS=2 ./node_modules/.bin/tsx verify-queue.ts
+# optionally: SAMPLE_VIDEO=/path/to/clip.mp4
+```
+
+Enqueues 3 jobs against the real queue and asserts that it drains every job,
+never exceeds the configured limit, and actually runs in parallel.

--- a/apps/remotion-server/server/render-queue.ts
+++ b/apps/remotion-server/server/render-queue.ts
@@ -3,17 +3,6 @@ import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
 /**
- * Render tuning — see REMOTION_PERFORMANCE.md (issue #6).
- *
- * `x264Preset: 'veryfast'` + a bounded off-thread video cache cut render time
- * ~21% in benchmarks with negligible quality cost. Concurrency is left at
- * Remotion's default unless `RENDER_CONCURRENCY` is set: forcing it higher was
- * neutral-to-worse on this encode-bound workload, while a container may want to
- * cap it *lower* to bound Chromium's memory footprint. `chromiumOptions.gl` is
- * intentionally NOT set — the fast value is platform-specific (`swangle` was 2×
- * slower on macOS), so only set `RENDER_GL` after benchmarking on the target OS.
- */
-/**
  * Reads a positive-integer env var. An invalid value warns loudly and falls
  * back rather than silently rendering with a bad setting — a typo'd
  * `MAX_CONCURRENT_RENDERS` should not quietly become `NaN`.
@@ -37,6 +26,17 @@ const positiveIntEnv = <T extends number | undefined>(name: string, fallback: T)
   return parsed;
 };
 
+/**
+ * Render tuning — see REMOTION_PERFORMANCE.md (issue #6).
+ *
+ * `x264Preset: 'veryfast'` + a bounded off-thread video cache cut render time
+ * ~21% in benchmarks with negligible quality cost. Concurrency is left at
+ * Remotion's default unless `RENDER_CONCURRENCY` is set: forcing it higher was
+ * neutral-to-worse on this encode-bound workload, while a container may want to
+ * cap it *lower* to bound Chromium's memory footprint. `chromiumOptions.gl` is
+ * intentionally NOT set — the fast value is platform-specific (`swangle` was 2×
+ * slower on macOS), so only set `RENDER_GL` after benchmarking on the target OS.
+ */
 const OFFTHREAD_VIDEO_CACHE_BYTES = positiveIntEnv('RENDER_OFFTHREAD_CACHE_MB', 2048) * 1024 * 1024;
 
 const RENDER_CONCURRENCY = positiveIntEnv('RENDER_CONCURRENCY', undefined);

--- a/apps/remotion-server/server/render-queue.ts
+++ b/apps/remotion-server/server/render-queue.ts
@@ -13,12 +13,36 @@ import path from 'node:path';
  * intentionally NOT set — the fast value is platform-specific (`swangle` was 2×
  * slower on macOS), so only set `RENDER_GL` after benchmarking on the target OS.
  */
-const OFFTHREAD_VIDEO_CACHE_BYTES =
-  Number(process.env.RENDER_OFFTHREAD_CACHE_MB ?? 2048) * 1024 * 1024;
+/**
+ * Reads a positive-integer env var. An invalid value warns loudly and falls
+ * back rather than silently rendering with a bad setting — a typo'd
+ * `MAX_CONCURRENT_RENDERS` should not quietly become `NaN`.
+ */
+const positiveIntEnv = <T extends number | undefined>(name: string, fallback: T): number | T => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
 
-const RENDER_CONCURRENCY = process.env.RENDER_CONCURRENCY
-  ? Number(process.env.RENDER_CONCURRENCY)
-  : undefined;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    console.warn(
+      `[render-queue] Invalid ${name}="${raw}" (expected a positive integer), using ${
+        fallback ?? "Remotion's default"
+      }`
+    );
+    return fallback;
+  }
+
+  return parsed;
+};
+
+const OFFTHREAD_VIDEO_CACHE_BYTES = positiveIntEnv('RENDER_OFFTHREAD_CACHE_MB', 2048) * 1024 * 1024;
+
+const RENDER_CONCURRENCY = positiveIntEnv('RENDER_CONCURRENCY', undefined);
+
+/** Per-render timeout. Stops a wedged job from occupying a slot forever. */
+const RENDER_TIMEOUT_MS = positiveIntEnv('RENDER_TIMEOUT_MS', 300_000);
 
 /**
  * How many render jobs run in parallel (Phase 2). This is distinct from
@@ -29,9 +53,7 @@ const RENDER_CONCURRENCY = process.env.RENDER_CONCURRENCY
  * Defaults to 1 (the previous strictly-sequential behaviour); the container
  * sets it to 2 to match the worker's dispatch concurrency.
  */
-const MAX_CONCURRENT_RENDERS = process.env.MAX_CONCURRENT_RENDERS
-  ? Math.max(1, Number(process.env.MAX_CONCURRENT_RENDERS))
-  : 1;
+const MAX_CONCURRENT_RENDERS = positiveIntEnv('MAX_CONCURRENT_RENDERS', 1);
 
 /**
  * Job data structure
@@ -123,6 +145,7 @@ export const makeRenderQueue = ({
     }
 
     const { cancel, cancelSignal } = makeCancelSignal();
+    let lastLoggedPercent = -1;
 
     jobs.set(jobId, {
       progress: 0,
@@ -154,9 +177,18 @@ export const makeRenderQueue = ({
         codec: 'h264',
         x264Preset: 'veryfast',
         offthreadVideoCacheSizeInBytes: OFFTHREAD_VIDEO_CACHE_BYTES,
+        timeoutInMilliseconds: RENDER_TIMEOUT_MS,
         ...(RENDER_CONCURRENCY ? { concurrency: RENDER_CONCURRENCY } : {}),
         onProgress: (progress) => {
-          console.info(`[${jobId}] Render progress: ${Math.round(progress.progress * 100)}%`);
+          // Job state updates on every tick (the client polls it), but only log
+          // when the whole percent changes — onProgress fires far more often
+          // than that, and concurrent renders interleave their output.
+          const percent = Math.round(progress.progress * 100);
+          if (percent !== lastLoggedPercent) {
+            lastLoggedPercent = percent;
+            console.info(`[${jobId}] Render progress: ${percent}%`);
+          }
+
           jobs.set(jobId, {
             progress: progress.progress,
             status: 'in-progress',

--- a/apps/remotion-server/server/render-queue.ts
+++ b/apps/remotion-server/server/render-queue.ts
@@ -21,6 +21,19 @@ const RENDER_CONCURRENCY = process.env.RENDER_CONCURRENCY
   : undefined;
 
 /**
+ * How many render jobs run in parallel (Phase 2). This is distinct from
+ * `RENDER_CONCURRENCY` above, which controls Chromium tabs *within* a single
+ * render — total Chromium load ≈ MAX_CONCURRENT_RENDERS × per-render
+ * concurrency, so size both against the host's RAM and `/dev/shm`.
+ *
+ * Defaults to 1 (the previous strictly-sequential behaviour); the container
+ * sets it to 2 to match the worker's dispatch concurrency.
+ */
+const MAX_CONCURRENT_RENDERS = process.env.MAX_CONCURRENT_RENDERS
+  ? Math.max(1, Number(process.env.MAX_CONCURRENT_RENDERS))
+  : 1;
+
+/**
  * Job data structure
  * Generic to support any composition with any input props
  */
@@ -57,7 +70,7 @@ type JobState =
 
 /**
  * Creates and manages a render job queue
- * Handles sequential rendering of video compositions
+ * Runs up to MAX_CONCURRENT_RENDERS video compositions in parallel
  */
 export const makeRenderQueue = ({
   port,
@@ -71,7 +84,33 @@ export const makeRenderQueue = ({
   publicUrl: string;
 }) => {
   const jobs = new Map<string, JobState>();
-  let queue: Promise<unknown> = Promise.resolve();
+
+  // Bounded concurrent scheduler: up to MAX_CONCURRENT_RENDERS jobs run at
+  // once; the rest wait in `pending` until a slot frees up.
+  const pending: string[] = [];
+  let active = 0;
+
+  /**
+   * Starts as many pending jobs as there are free slots. Safe to call
+   * repeatedly — it no-ops when the pool is full or the queue is empty.
+   */
+  const pump = () => {
+    while (active < MAX_CONCURRENT_RENDERS && pending.length > 0) {
+      const jobId = pending.shift() as string;
+      active++;
+      // processRender records its own failures on the job; the catch is a
+      // safety net (e.g. a job cancelled out from under us). Either way, free
+      // the slot and pump the next job.
+      void processRender(jobId)
+        .catch((error) => {
+          console.error(`[${jobId}] Unexpected render error:`, error);
+        })
+        .finally(() => {
+          active--;
+          pump();
+        });
+    }
+  };
 
   /**
    * Processes a render job
@@ -146,19 +185,25 @@ export const makeRenderQueue = ({
   };
 
   /**
-   * Adds a job to the render queue
+   * Adds a job to the render queue. Runs immediately if a slot is free,
+   * otherwise waits its turn in `pending`.
    */
   const queueRender = async ({ jobId, data }: { jobId: string; data: JobData }) => {
     jobs.set(jobId, {
       status: 'queued',
       data,
       cancel: () => {
+        // Drop it from the waiting list so pump() never picks up a cancelled job.
+        const index = pending.indexOf(jobId);
+        if (index !== -1) {
+          pending.splice(index, 1);
+        }
         jobs.delete(jobId);
       },
     });
 
-    // Add to queue - processes sequentially
-    queue = queue.then(() => processRender(jobId));
+    pending.push(jobId);
+    pump();
   };
 
   /**

--- a/apps/remotion-server/verify-queue.ts
+++ b/apps/remotion-server/verify-queue.ts
@@ -1,0 +1,131 @@
+/**
+ * Phase 2 verification: prove the bounded concurrent queue actually runs
+ * multiple renders in parallel, never exceeds MAX_CONCURRENT_RENDERS, and
+ * drains every job to completion.
+ *
+ * Run: MAX_CONCURRENT_RENDERS=2 npx tsx verify-queue.ts
+ */
+import { bundle } from '@remotion/bundler';
+import { ensureBrowser } from '@remotion/renderer';
+import { createReadStream, mkdirSync, rmSync, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+import { makeRenderQueue } from './server/render-queue.js';
+
+const EXPECTED_LIMIT = Number(process.env.MAX_CONCURRENT_RENDERS ?? 1);
+const JOB_COUNT = 3;
+const VIDEO_PORT = 4601;
+// Any local mp4 works. `apps/processing-engine/output/` is gitignored, so
+// point SAMPLE_VIDEO at a file you have.
+const SAMPLE = path.resolve(
+  process.env.SAMPLE_VIDEO ?? '../processing-engine/output/A999_11151216_C035_clip_0s.mp4'
+);
+const OUT_DIR = path.join(os.tmpdir(), 'remotion-queue-verify');
+
+function startVideoServer() {
+  const size = statSync(SAMPLE).size;
+  const server = createServer((req, res) => {
+    const range = req.headers.range;
+    if (range) {
+      const [s, e] = range.replace(/bytes=/, '').split('-');
+      const start = parseInt(s, 10);
+      const end = e ? parseInt(e, 10) : size - 1;
+      res.writeHead(206, {
+        'Content-Range': `bytes ${start}-${end}/${size}`,
+        'Accept-Ranges': 'bytes',
+        'Content-Length': end - start + 1,
+        'Content-Type': 'video/mp4',
+      });
+      createReadStream(SAMPLE, { start, end }).pipe(res);
+    } else {
+      res.writeHead(200, { 'Content-Length': size, 'Content-Type': 'video/mp4' });
+      createReadStream(SAMPLE).pipe(res);
+    }
+  });
+  return new Promise<ReturnType<typeof createServer>>((resolve) =>
+    server.listen(VIDEO_PORT, () => resolve(server))
+  );
+}
+
+async function main() {
+  console.log(`\n=== Phase 2 queue verification ===`);
+  console.log(`MAX_CONCURRENT_RENDERS=${EXPECTED_LIMIT}, enqueuing ${JOB_COUNT} jobs\n`);
+
+  rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  await ensureBrowser();
+  const videoServer = await startVideoServer();
+
+  const serveUrl = await bundle({
+    entryPoint: path.resolve('../../packages/remotion-compositions/src/index.ts'),
+  });
+
+  const queue = makeRenderQueue({
+    port: 3001,
+    serveUrl,
+    rendersDir: OUT_DIR,
+    publicUrl: 'http://localhost:3001',
+  });
+
+  // Short renders (60 frames = 2s) so the test finishes quickly.
+  const inputProps = {
+    videoUrl: `http://localhost:${VIDEO_PORT}/video.mp4`,
+    subtitles: [{ id: 1, start: 0, end: 2, text: 'queue verification' }],
+    template: 'viral',
+    language: 'en',
+    aspectRatio: '9:16',
+    backgroundColor: '#000000',
+    durationInFrames: 60,
+  };
+
+  const jobIds = Array.from({ length: JOB_COUNT }, () =>
+    queue.createJob({ compositionId: 'VideoWithSubtitles', inputProps })
+  );
+
+  // Sample the queue and record peak simultaneous in-progress renders.
+  let peak = 0;
+  const sampler = setInterval(() => {
+    let inProgress = 0;
+    for (const id of jobIds) {
+      if (queue.jobs.get(id)?.status === 'in-progress') inProgress++;
+    }
+    peak = Math.max(peak, inProgress);
+  }, 50);
+
+  const start = Date.now();
+  while (Date.now() - start < 300_000) {
+    const states = jobIds.map((id) => queue.jobs.get(id)?.status);
+    if (states.every((s) => s === 'completed' || s === 'failed')) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  clearInterval(sampler);
+
+  const finalStates = jobIds.map((id) => queue.jobs.get(id)?.status);
+  const completed = finalStates.filter((s) => s === 'completed').length;
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+
+  console.log(`\n--- Results ---`);
+  console.log(`states:            ${finalStates.join(', ')}`);
+  console.log(`completed:         ${completed}/${JOB_COUNT}`);
+  console.log(`peak concurrent:   ${peak} (limit ${EXPECTED_LIMIT})`);
+  console.log(`wall clock:        ${elapsed}s`);
+
+  const drained = completed === JOB_COUNT;
+  const bounded = peak <= EXPECTED_LIMIT;
+  const parallel = EXPECTED_LIMIT === 1 || peak > 1;
+
+  console.log(`\ndrained all jobs:  ${drained ? 'PASS' : 'FAIL'}`);
+  console.log(`respected limit:   ${bounded ? 'PASS' : 'FAIL'}`);
+  console.log(`ran in parallel:   ${parallel ? 'PASS' : 'FAIL'}`);
+
+  videoServer.close();
+  process.exit(drained && bounded && parallel ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error('Verification failed:', e);
+  process.exit(1);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,9 @@ services:
       # container (see REMOTION_PERFORMANCE.md). Raise/remove on hosts with
       # more RAM; leave unset to use Remotion's default (~half the cores).
       - RENDER_CONCURRENCY=2
+      # Run up to 2 render jobs in parallel, matching the worker's dispatch
+      # concurrency. Total Chromium tabs ≈ this × RENDER_CONCURRENCY (=4 here).
+      - MAX_CONCURRENT_RENDERS=2
     volumes:
       - ./packages/remotion-compositions:/app/packages/remotion-compositions
       - ./apps/remotion-server/server:/app/apps/remotion-server/server


### PR DESCRIPTION
Part of #6. **Stacked on #15** (base = `feature/remotion-render-perf-phase1`) — review/merge that one first; GitHub will retarget this to `main` automatically.

> **Supersedes draft PR #12.** That 4.5-month-old bot draft (14 commits behind main) independently converged on the same pool design. I've ported its three genuinely useful pieces here (see below) and deliberately left out its `enableMultiProcessOnLinux: true`, which caused the Chromium `/dev/shm` exhaustion. #12 can be closed once this lands.

## Problem
The Remotion server serialized *every* render:

```ts
queue = queue.then(() => processRender(jobId));
```

So the worker could dispatch 2 render jobs (`concurrency=2`), but the server still ran them one at a time. That's the structural throughput ceiling identified as **B1** in the investigation.

## Change
Replaces the promise chain with a **bounded concurrent pool**:
- `pending` list + `active` counter + `pump()` starts as many jobs as there are free slots.
- Cancelling a *queued* job now also removes it from `pending`, so `pump()` never picks up a dead job.

Ported from #12:
- **`RENDER_TIMEOUT_MS`** (default 5 min) → `renderMedia`'s `timeoutInMilliseconds`. Matters more now that pool slots are finite — a wedged render would otherwise hold a slot forever.
- **Env validation** via a shared `positiveIntEnv()` helper: an invalid value warns and falls back instead of silently becoming `NaN`. Applied to all four knobs (#12 validated three).
- **Progress-log throttling** to whole-percent changes; `onProgress` fires far more often than that and concurrent renders interleave. Job state still updates every tick so client polling stays accurate.

## Tuning knobs

| Env | Controls | Default | Container |
|---|---|---|---|
| `MAX_CONCURRENT_RENDERS` | render **jobs** in parallel | 1 | 2 |
| `RENDER_CONCURRENCY` | Chromium **tabs** within one render | Remotion default | 2 |
| `RENDER_TIMEOUT_MS` | per-render timeout | 300000 | — |
| `RENDER_OFFTHREAD_CACHE_MB` | off-thread video cache | 2048 | — |

The first two are deliberately separate — total Chromium load ≈ their product, so size both against RAM and `/dev/shm`.

**Defaults to 1**, i.e. identical to the previous behaviour. Only the container opts into 2 (2 jobs × 2 tabs = 4 tabs).

## Verification
`verify-queue.ts` (new) enqueues 3 jobs against the **real** queue and asserts it drains everything, never exceeds the limit, and actually runs in parallel:

| Setting | Peak concurrent | Completed | Wall clock |
|---|---|---|---|
| default (=1) | 1 | 3/3 | 11.7s |
| `MAX_CONCURRENT_RENDERS=2` | 2 | 3/3 | **10.1s** |

```
drained all jobs:  PASS
respected limit:   PASS
ran in parallel:   PASS
```

Re-verified after porting the #12 improvements (3/3, peak 2, all PASS). `tsc --noEmit` passes; lint clean.

## Honest caveat on the number
The ~14% here is modest because each render *already* uses ~half the cores by default, so 2 jobs × 6 tabs saturates a 12-core box. The gain is larger where per-render concurrency is **capped** (the container) or on hosts with spare cores. The point of this PR is that the hard serialization ceiling is gone — throughput now scales with the box instead of being pinned at 1.

## Not included (Phase 3)
Pre-bundle at build + `REMOTION_SERVE_URL`, production Dockerfile build stage (there is currently **no** build step, which is why compose falls back to `pnpm dev`), render metrics/limits, hardware accel / distributed rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)